### PR TITLE
feat: bump to version 18.11.1213

### DIFF
--- a/3cx.nuspec
+++ b/3cx.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>3cx</id>
-    <version>16.3.0.264</version>
+    <version>18.11.1213</version>
     <packageSourceUrl>https://github.com/basictheprogram/chocolatey-3cx</packageSourceUrl>
     <owners>basictheprogram</owners>
     <title>3CX Client for Windows</title>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,7 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
-$fullPackage = "3CXPhoneforWindows16.msi"
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://downloads-global.3cx.com/downloads/' + $fullPackage
+$url = 'https://1243.3cx.cloud/webclient/api/app/windows'
 
 $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
@@ -9,7 +8,7 @@ $packageArgs = @{
     fileType       = 'msi'
     url            = $url
     softwareName   = '3CX*'
-    checksum       = 'd8e563b9591282986d493a60dda0a5311b94b1dd61aad01b50df674b48207485'
+    checksum       = '0031836e535ec47599e42070028c73fada617b2a9fd597034de76f43599162a7'
     checksumType   = 'sha256'
     silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
     validExitCodes = @(0, 3010, 1641)


### PR DESCRIPTION
@basictheprogram did a version bump for 3cx. It seems that they no longer have a public accessible download URL, but a private cloud hosted instance does not require authentication so we can still download the latest from there. 